### PR TITLE
Added config.delay and fixed saving config to sensor

### DIFF
--- a/main.js
+++ b/main.js
@@ -279,19 +279,13 @@ function startAdapter(options) {
                     });
                 }
             });
-        }else if(dp === 'offset'){
+        } else if(dp === 'offset' || dp === 'sensitivity' || dp === 'usertest' || dp === 'ledindication' || dp === 'duration' || dp === 'delay') {
             adapter.getObject(adapter.name + '.' + adapter.instance + '.' + id, function(err, obj) {
                 let controlId = obj.native.id;
-                let parameters = `{ "offset": "${state.val}" }`;
-                setSensorParameters(parameters, controlId, adapter.name + '.' + adapter.instance + '.' + id + '.offset')
+                let parameters = `{ "${dp}": "${state.val}" }`;
+                setSensorParameters(parameters, controlId, adapter.name + '.' + adapter.instance + '.' + id + '.' + dp)
             });
-        }else if(dp === 'duration'){
-            adapter.getObject(adapter.name + '.' + adapter.instance + '.' + id, function(err, obj) {
-                let controlId = obj.native.id;
-                let parameters = `{ "duration": "${state.val}" }`;
-                setSensorParameters(parameters, controlId, adapter.name + '.' + adapter.instance + '.' + id + '.duration')
-            });
-        }
+        } //on is not working
     })
 },
 //END on StateChange

--- a/main.js
+++ b/main.js
@@ -616,6 +616,7 @@ function getAutoUpdates(){
                                                 case 'ledindication':
                                                 case 'usertest':
                                                 case 'battery':
+                                                case 'delay':
                                                 case 'reachable':
                                                 case 'alert':
                                                 case 'duration':
@@ -1502,6 +1503,7 @@ function getAllSensors() {
                                     ack: true
                                 });
                                 break;
+                            case 'delay':
                             case 'duration':
                                 adapter.setObjectNotExists(`Sensors.${sensorID}` + '.' + stateName, {
                                     type: 'state',
@@ -1849,6 +1851,7 @@ function getSensor(sensorId){
                                     ack: true
                                 });
                                 break;
+                            case 'delay':
                             case 'duration':
                                 adapter.setObjectNotExists(`Sensors.${sensorId}` + '.' + stateName, {
                                     type: 'state',


### PR DESCRIPTION
I was looking for a way to edit presence sensor delay (https://github.com/dresden-elektronik/deconz-rest-plugin/issues/1815#issuecomment-527370500) in my Hue sensors. Added that. Also figured out that saving the config wasn't possible (with a few exceptions). Fixed that as well.