### PR TITLE
Reduce info logging

### DIFF
--- a/main.js
+++ b/main.js
@@ -1939,7 +1939,7 @@ function setSensorParameters(parameters, sensorId, stateId, callback){
         adapter.log.debug('STATUS: ' + res.statusCode);
         let response;
         try{response = JSON.parse(body);} catch(err){}
-        adapter.log.info('options: ' + JSON.stringify(options));
+        adapter.log.debug('options: ' + JSON.stringify(options));
         adapter.log.debug('setSensorParameters BODY: ' + JSON.stringify(response));
 
         if(res.statusCode === 200){
@@ -2462,7 +2462,7 @@ function setLightState(parameters, lightId, stateId, callback){
             adapter.log.debug('STATUS: ' + res.statusCode);
             let response;
             try{response = JSON.parse(body);} catch(err){}
-            adapter.log.info('options: ' + JSON.stringify(options));
+            adapter.log.debug('options: ' + JSON.stringify(options));
             adapter.log.debug('setLightState BODY: ' + JSON.stringify(response));
 
             if(res.statusCode === 200){


### PR DESCRIPTION
Reducing `info` logging from e.g.
```
deconz.0 | 2019-11-11 15:34:42.422 | info | (3042) options:  {"url":"http://192.168.X.X:80/api/XXX/lights/4/state","method":"PUT","headers":"Content-Type\"  : \"application/json","body":"{\"on\": false}"}
deconz.0 | 2019-11-11 15:34:42.400 | info | (3042) setLightState: {"on": false} 4 deconz.0.Lights.4.on
```
to only
```
deconz.0 | 2019-11-11 15:34:42.400 | info | (3042) setLightState: {"on": false} 4 deconz.0.Lights.4.on
```

by setting first one to `debug`.