### PR TITLE
add transitiontime to setLightState when using bri_inc (dim step)

### DIFF
--- a/main.js
+++ b/main.js
@@ -211,7 +211,7 @@ async function startAdapter(options) {
                     }
                     let speed = dp === 'dimup' ? dimspeed.val : dimspeed.val * -1;
                     let controlId = obj.native.id;
-                    let parameters = `{ "bri_inc": ${speed} }`;
+                    let parameters = '{ "transitiontime": ' + JSON.stringify(ttime) + `, "bri_inc": ${speed} }`;
                     switch(obj.common.role){
                         case 'group':
                             setGroupState(parameters, controlId, adapter.name + '.' + adapter.instance + '.' + id + '.bri');


### PR DESCRIPTION
Motivation: The illuminize zigbee dimmer for some reason does not dim
smoothly when using the "move to level" (0x00) zigbee command with
a transition time. However it does dim smoothly when using the
"step" (0x02) zigbee command instead.

Because deCONZ applies the transition time to the payload correctly,
this can be used as a workaround.