### PR TITLE
Remove overwriting of ipaddress

### DIFF
--- a/main.js
+++ b/main.js
@@ -798,7 +798,6 @@ async function getConfig(){
                         dhcp: gateway['dhcp'],
                         factorynew: gateway['factorynew'],
                         gateway: gateway['gateway'],
-                        ipaddress: gateway['ipaddress'],
                         linkbutton: gateway['linkbutton'],
                         mac: gateway['mac'],
                         modelid: gateway['modelid'],


### PR DESCRIPTION
When the user set the deconz IP already, we don't need to change it based on the config that deconz provides. If there is a connection already established, there is no need to change it at all.

Fixes #94