### PR TITLE
change bri role to level brightness

### DIFF
--- a/main.js
+++ b/main.js
@@ -2002,7 +2002,7 @@ function SetObjectAndState(id, name, type, stateName, value) {
             break;
         case 'bri':
             objType = 'number';
-            objRole = 'value.brightness';
+            objRole = 'level.brightness';
             objMin = 0;
             objMax = 254;
             objDefault = 254;


### PR DESCRIPTION
bri is a value you can change this means it is a level not a value. This will allow the type detector to recognize the correct element and all adapter which are using the type detector like the iot Adapterr.