### PR TITLE
maxlength for api key

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -418,7 +418,7 @@
             </div>
             <div class="row">
                 <div class="input-field col s12 m2 14">
-                    <input class="value text" id="user" size="20" maxlength="20" type="text">
+                    <input class="value text" id="user" size="20" maxlength="40" type="text">
                     <label class="translate active" for="user" data-lang="API key">API key</label>
                 </div>
                 <div class="input-field col s6 m2">


### PR DESCRIPTION
The API Key can be 10-40 char (http://dresden-elektronik.github.io/deconz-rest-doc/configuration/)