### PR TITLE
Use change-event for updating the object parameters

### DIFF
--- a/main.js
+++ b/main.js
@@ -716,20 +716,18 @@ async function getAutoUpdates() {
             switch (type) {
                 case 'lights':
                     if (typeof state == 'object') {
-                        adapter.log.debug("Event has state-tag: Attributes will be updated");
-                        // This makes only sense, if deconf.config.websocketnotifyall is set to false
+                        adapter.log.debug("Event has state-tag");
                         if(Object.keys(state).length > 0) {
                             object = await getObjectByDeviceId(id, 'Lights');
                             for (let stateName in state) {
                                 adapter.log.debug(stateName + ": "+ state[stateName]);
-                                new SetObjectAndState(id, object.value.common.name, 'Lights', stateName, state[stateName]);
-                           }
+                                new SetObjectAndState(id, object.value.common.name, 'Lights', stateName, state[stateNam>                           }
                         } else {
                             adapter.log.debug("Event has no state-Changes");
                             // no state objects
                         }
                     } else if (typeof attr == 'object') {
-                        adapter.log.debug("Event has attr-Tag: No Update-Mechanism implemented");
+                        adapter.log.debug("Event has attr-Tag");
                         // in this case the new "attr"-attribute of the new event (lastseen) can be checked
                     } else {
                         await getLightState(id);

--- a/main.js
+++ b/main.js
@@ -721,7 +721,7 @@ async function getAutoUpdates() {
                             object = await getObjectByDeviceId(id, 'Lights');
                             for (let stateName in state) {
                                 adapter.log.debug(stateName + ": "+ state[stateName]);
-                                new SetObjectAndState(id, object.value.common.name, 'Lights', stateName, state[stateNam>                           }
+                                new SetObjectAndState(id, object.value.common.name, 'Lights', stateName, state[stateNam]);                           }
                         } else {
                             adapter.log.debug("Event has no state-Changes");
                             // no state objects

--- a/main.js
+++ b/main.js
@@ -721,7 +721,7 @@ async function getAutoUpdates() {
                             object = await getObjectByDeviceId(id, 'Lights');
                             for (let stateName in state) {
                                 adapter.log.debug(stateName + ": "+ state[stateName]);
-                                new SetObjectAndState(id, object.value.common.name, 'Lights', stateName, state[stateNam]);                           }
+                                new SetObjectAndState(id, object.value.common.name, 'Lights', stateName, state[stateName]);                           }
                         } else {
                             adapter.log.debug("Event has no state-Changes");
                             // no state objects

--- a/main.js
+++ b/main.js
@@ -714,7 +714,18 @@ async function getAutoUpdates() {
             let object;
             switch (type) {
                 case 'lights':
-                    await getLightState(id);
+                    if (typeof state == 'object') {
+                        if(Object.keys(state).length > 0) {
+                            object = await getObjectByDeviceId(id, 'Lights');
+                            for (let stateName in state) {
+                                new SetObjectAndState(id, object.value.common.name, 'Lights', stateName, state[stateName]);
+                           }
+                        } else {
+                            // in this case the new "attr"-attribute of the new event (lastseen) can be checked
+                        }
+                    } else {
+                        await getLightState(id);
+                    }
                     break;
                 case 'groups':
                 case 'scenes':

--- a/main.js
+++ b/main.js
@@ -707,6 +707,7 @@ async function getAutoUpdates() {
             let id = data['id'] ? data['id'] : data['gid'];
             let type = data['r'];
             let state = data['state'];
+            let attr = data['attr'];
             let config = data['config'];
             adapter.log.debug('Websocket message: ' + JSON.stringify(data));
 
@@ -715,14 +716,21 @@ async function getAutoUpdates() {
             switch (type) {
                 case 'lights':
                     if (typeof state == 'object') {
+                        adapter.log.debug("Event has state-tag: Attributes will be updated");
+                        // This makes only sense, if deconf.config.websocketnotifyall is set to false
                         if(Object.keys(state).length > 0) {
                             object = await getObjectByDeviceId(id, 'Lights');
                             for (let stateName in state) {
+                                adapter.log.debug(stateName + ": "+ state[stateName]);
                                 new SetObjectAndState(id, object.value.common.name, 'Lights', stateName, state[stateName]);
                            }
                         } else {
-                            // in this case the new "attr"-attribute of the new event (lastseen) can be checked
+                            adapter.log.debug("Event has no state-Changes");
+                            // no state objects
                         }
+                    } else if (typeof attr == 'object') {
+                        adapter.log.debug("Event has attr-Tag: No Update-Mechanism implemented");
+                        // in this case the new "attr"-attribute of the new event (lastseen) can be checked
                     } else {
                         await getLightState(id);
                     }


### PR DESCRIPTION
Hello guys,

with https://github.com/dresden-elektronik/deconz-rest-plugin/pull/2849 a new mechanism for eventing was introduced.
Therefore two attributes within the change-event are now available:
1. attr // all the time -> lastseen-event is updated all the time
2. state // rare -> only on changes (websocketnotifyall: false makes sense - otherwise every attribute is sent)

The Pull-request will handle the changed attributes of "state" now.
Only the attributes within this tage are saved to the iobroker-object.

The old functionality was, that for every change-attribute the whole light-state was requested.
With the new last-seen-functionality, this will result in a request to deconz every second.

This is a solution for https://github.com/iobroker-community-adapters/ioBroker.deconz/issues/150.

Regards
bortim