### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "type": "git",
     "url": "https://github.com/Jey-Cee/ioBroker.deconz"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "3.0.3",
     "request": "2.88.2",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installed at node 14 or older due to npm 6 not installing peerDependencies. So this adapter requires node 16