### PR TITLE
Fix for invalid jsonConfig message

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -51,8 +51,7 @@
           "sm": 12,
           "xs": 12,
           "newLine": true,
-          "style": { "font-size": "16px",  "text-align": "center", "background-color":  "rgb(224, 224, 224)", "border-radius":  "3px", "padding": "10px"},
-          "darkStyle": { "color": "black","font-size": "16px",  "text-align": "center", "background-color":  "rgb(224, 224, 224)", "border-radius":  "3px", "padding": "10px"}
+          "style": { "color": "black", "font-size": "16px",  "text-align": "center", "background-color":  "rgb(224, 224, 224)", "radiusBorder":  "3px", "padding": "10px"}
         },
         "user": {
           "label": "API key",
@@ -100,8 +99,7 @@
           "sm": 12,
           "xs": 12,
           "newLine": true,
-          "style": { "font-size": "16px",  "text-align": "center", "background-color":  "rgb(224, 224, 224)", "border-radius":  "3px", "padding": "10px"},
-          "darkStyle": { "color": "black","font-size": "16px",  "text-align": "center", "background-color":  "rgb(224, 224, 224)", "border-radius":  "3px", "padding": "10px"}
+          "style": { "color": "black", "font-size": "16px",  "text-align": "center", "background-color":  "rgb(224, 224, 224)", "radiusBorder":  "3px", "padding": "10px"}
         },
         "username": {
           "label": "Username",


### PR DESCRIPTION
`warn: admin.0 (822) deconz has an invalid jsonConfig: [{"instancePath":"/items/_instruction/darkStyle","schemaPath":"#/properties/items/patternProperties/%5E.%2B/properties/darkStyle/type","keyword":"type","params":{"type":"string"},"message":"must be string"},{"instancePath":"","schemaPath":"#/if","keyword":"if","params":{"failingKeyword":"else"},"message":"must match \"else\" schema"}]`

### Nothing has changed in terms of optics.