### PR TITLE
fix: make UTCtoLocal robust against invalid/already-timezone-aware timestamps (fixes #461)

### DIFF
--- a/main.js
+++ b/main.js
@@ -2417,7 +2417,15 @@ function ackStateVal(stateId, response) {
  */
 function UTCtoLocal(timeString) {
     if (timeString !== 'none' && timeString !== null && timeString !== undefined) {
-        let jsT = Date.parse(`${timeString}Z`);
+        const raw = String(timeString).trim();
+        const hasTz = /(?:Z|[+-]\d{2}:\d{2})$/.test(raw);
+        const normalized = hasTz ? raw : `${raw}Z`;
+        let jsT = Date.parse(normalized);
+
+        if (!Number.isFinite(jsT)) {
+            adapter.log.warn(`UTCtoLocal: invalid timestamp value "${raw}", returning as-is`);
+            return raw;
+        }
 
         let d = new Date();
         let n = d.getTimezoneOffset();


### PR DESCRIPTION
## Problem

During the DST switch on 2026-03-29, the adapter entered a crash loop with:

```
RangeError: Invalid time value in UTCtoLocal (main.js:2306)
```

**Root cause:** `UTCtoLocal()` blindly appends `Z` to every timestamp string:

```js
let jsT = Date.parse(`${timeString}Z`);
```

If deConz sends a timestamp that already includes a timezone offset (e.g. `2026-03-29T02:00:00+01:00`), the result becomes `...+01:00Z` — an invalid date string. `Date.parse()` returns `NaN`, and `new Date(NaN).toISOString()` throws `RangeError: Invalid time value`, which crashes the adapter. On restart the same state is replayed → crash loop.

## Fix

- Detect if the timestamp already contains timezone info (`Z` or `±HH:MM` suffix)
- Only append `Z` when no timezone is present
- Guard against `NaN`: log a warning and return the raw value unchanged instead of crashing

## Changes

`main.js` — `UTCtoLocal()` function made robust against unexpected timestamp formats.

Closes #461