### PR TITLE
chore: update GitHub Actions to v6 (Node.js 24 compatibility)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check.outputs.has_changes == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.x'
 
@@ -70,6 +70,8 @@ jobs:
           # Bump patch version in package.json
           NEW_VERSION=$(npm version patch --no-git-tag-version)
           VERSION=${NEW_VERSION#v}
+          export VERSION
+          export DATE=$(date +%Y-%m-%d)
           echo "New version: ${VERSION}"
 
           # Update io-package.json
@@ -110,7 +112,6 @@ jobs:
           "
 
           # Update README.md changelog
-          DATE=$(date +%Y-%m-%d)
           CHANGELOG_ENTRY="### ${VERSION} (${DATE})"$'\n'"${CHANGELOG_EN}"$'\n'
 
           # Insert after the "## Changelog" line (before first existing version entry)


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be force-migrated to Node.js 24 on **June 2nd, 2026**.

## Changes

- `actions/checkout`: v3/v4 → **v6**
- `actions/setup-node`: v4 → **v6**

Affected workflows: `codeql.yml`, `monthly-release.yml`