### PR TITLE
fix: remove [skip ci] from release commit so npm publish works

### DIFF
--- a/.github/workflows/monthly-release.yml
+++ b/.github/workflows/monthly-release.yml
@@ -181,6 +181,6 @@ jobs:
           # Commit and tag
           git add package.json io-package.json README.md
           [ -f package-lock.json ] && git add package-lock.json
-          git commit -m "chore: release v${VERSION} [skip ci]"
+          git commit -m "chore: release v${VERSION}"
           git tag "v${VERSION}"
           git push origin HEAD --tags


### PR DESCRIPTION
## Problem

The monthly release workflow commited with `[skip ci]` in the message:

```
git commit -m "chore: release v${VERSION} [skip ci]"
```

GitHub skips **all** workflows triggered by a commit with `[skip ci]` — including tag-triggered ones, because the tag points to that same commit. So `test-and-release.yml` never ran → adapter was never published to npm.

## Fix

Remove `[skip ci]` from the commit message.